### PR TITLE
Added extra signature of unencrpyted data required in .NET validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aspxauth
 
+**Note:** There are many variables, flags, and version-specific considerations for how .NET generates the `.aspxauth` cookie. This library works for our needs using older versions of the .NET framework. Your milage may vary.
+
 Provides utilities to assist in generating, validating and decrypting .NET authorization tickets (usually set in the .ASPXAUTH cookie) for interoperation with .NET authentication.
 
 ## Setup

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -57,6 +57,14 @@ describe( "aspxauth#decrypt", () => {
 		} );
 	} );
 
+	describe( "when signature on unencrypted bytes does not match hash", () => {
+		it( "should return null", function() {
+			token = "d522006c09b3cdc7cc77e5fce18e4049a4a0532c60111c35abf1c431ed36deebbc0eaf50f2c085e504f59e41c4f17952c1fbdf3afccc530da188b2577ff0aa65dea41e2cce59b6b657c3f5f869c52a75f0aa0a22f700656b5b7ba01b3f39a64f8b36742ad82fc53073556e8b87eb12ccb04ed027f4cd07aa726519e54a7112c324306c41b1a9df8f06b04aebf07e0a881b02a5981555040bc63fe3410210f0bbfd26ada59f5cc73e5dfe7bc52faef2be82f5699891ace2ac8f84104b67f9a6e927a12791be72479e2a63732c457479228c3c8be34fdc880e44d0b6e46b909c1f8df7921fb320b166f4a54bfc276325afe4504ea9e4b270050676447dd6d4f6d7f96ce61562e166ceb56c1d0d7df5e269775ed4f553cf7726b75426d6164f0cfff973225c";
+			configAndDecrypt();
+			( result === null ).should.be.true; // eslint-disable-line no-unused-expressions
+		} );
+	} );
+
 	describe( "when token is a buffer", () => {
 		it( "should return token object", function() {
 			token = Buffer.from( token, "hex" );


### PR DESCRIPTION
For .NET to successfully validate cookies encrypted by this lib, we needed to add an additional hash of the unencrpyted data (there is already a hash of the encrypted data).

- In encrypt, adds additional hash of unencrypted data (minus the initial 32 random bytes)
- In decrypt, adds validation of the additional signature